### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ authors = ["Matthieu Le brazidec (r3v2d0g) <r3v2d0g@jesus.gg>"]
 edition = "2018"
 
 [dependencies]
-async-io = "1.1"
-pin-project-lite = "0.1"
+async-io = "2.4"
+pin-project-lite = "0.2"
 
 [dev-dependencies]
-futures-lite = "1.8"
+futures-lite = "2.6"


### PR DESCRIPTION
Since a while `cargo-deny` complains about unmaintained dependencies which get used by `smol-timeout`. Fortunately can be fixed quite easily by upgrading the dependencies. Would be great if you could push an updated version of `smol-timeout` on crates.io. 

```
error[unmaintained]: `instant` is unmaintained
    ┌─ /run/build/shortwave/Cargo.lock:178:1
    │
178 │ instant 0.1.13 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
    │
    ├ ID: RUSTSEC-2024-0384
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0384
    ├ This crate is no longer maintained, and the author recommends using the maintained [`web-time`] crate instead.
      
      [`web-time`]: https://crates.io/crates/web-time
    ├ Solution: No safe upgrade is available!
    ├ instant v0.1.13
      └── fastrand v1.9.0
          └── futures-lite v1.13.0
              └── async-io v1.13.0
                  └── smol-timeout v0.6.0
```